### PR TITLE
BugFix: Securiy Config 에서 루트 경로 접근 시 401 에러가 발생하는 현상 수정

### DIFF
--- a/src/main/java/com/example/dm/security/SecurityConfig.java
+++ b/src/main/java/com/example/dm/security/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @RequiredArgsConstructor
 @Configuration
@@ -36,7 +37,7 @@ public class SecurityConfig {
                 .csrf(CsrfConfigurer::disable)
                 .sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/").permitAll()
+                        .requestMatchers("/", "/**").permitAll()
                         .requestMatchers("/actuator/health").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## BugFix: Securiy Config 에서 루트 경로 접근 시 401 에러가 발생하는 현상 수정 #3 

- Security Config 설정에서 루트 경로(`/`) 에 대한 접근 권한이 permitAll 로 설정되어 있음에도 불구하고, 해당 경로 접근 시 401 에러가 뜨던 현상 발생
- permitAll 경로에 `/**` 를 추가해주어서, 루트 경로(`/`)에 대한 URI의 권한을 모두 허용시켜 줌으로써 해결함
- 추후 JWT 검증 필터가 적용되면 재설정 필요

### 기존 응답
```json
{
    "txid": "eac656d4-add2-4909-8605-7ca8b1486b49",
    "status": 401,
    "message": "로그인 정보를 찾을 수 없습니다.",
    "error": {
        "code": "E4010",
        "description": "UNAUTHORIZED"
    }
}
```
### 수정 후 응답
```json
{
    "timestamp": "2023-09-05T13:03:04.302+00:00",
    "status": 404,
    "error": "Not Found",
    "message": "No message available",
    "path": "/"
}
```