### PR TITLE
Add: 전역 Logging 모듈 추가

### DIFF
--- a/src/main/java/com/example/dm/aspect/CustomRequestWrapper.java
+++ b/src/main/java/com/example/dm/aspect/CustomRequestWrapper.java
@@ -1,0 +1,111 @@
+package com.example.dm.aspect;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.util.Strings;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+public class CustomRequestWrapper extends HttpServletRequestWrapper {
+    private final Charset encoding;
+    private final byte[] rawData;
+
+    public CustomRequestWrapper(HttpServletRequest request) throws IOException {
+        super(request);
+
+        String characterEncoding = request.getCharacterEncoding();
+        if (Strings.isBlank(characterEncoding)) {
+            characterEncoding = StandardCharsets.UTF_8.name();
+        }
+        this.encoding = Charset.forName(characterEncoding);
+
+        try {
+            InputStream inputStream = request.getInputStream();
+            this.rawData = toByteArray(inputStream);
+            String requestBody = new String(rawData, StandardCharsets.UTF_8);
+
+            writeRequestLogs(request, requestBody);
+
+        } catch (IOException e) {
+            throw e;
+        }
+    }
+
+    /**
+     * 공통 Request 로그 작성
+     */
+    private void writeRequestLogs(HttpServletRequest request, String requestBody) {
+        String requestId = (String) request.getAttribute("requestId");
+        String publicIp = (String) request.getAttribute("publicIp");
+        String userAgent = request.getHeader("user-agent");
+        String requestMethod = request.getMethod();
+        String servletPath = request.getServletPath();
+        String queryString = !Strings.isEmpty(request.getQueryString()) ? "?" + request.getQueryString() : "";
+
+        log.info("-------------------------------------");
+        log.info("[Request] => {}", requestId);
+        log.info("{} {} {}", requestId, requestMethod, servletPath + queryString);
+        log.info("{} public ip:{}", requestId, publicIp);
+        log.info("{} user-agent:{}", requestId, userAgent);
+        log.info("{} request body=[{}]", requestId, requestBody);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(this.rawData);
+        return new ServletInputStream() {
+            @Override
+            public boolean isFinished() {
+                return false;
+            }
+
+            @Override
+            public boolean isReady() {
+                return false;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+
+            }
+
+            public int read() throws IOException {
+                return byteArrayInputStream.read();
+            }
+        };
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        return new BufferedReader(new InputStreamReader(this.getInputStream(), this.encoding));
+    }
+
+    @Override
+    public ServletRequest getRequest() {
+        return super.getRequest();
+    }
+
+    /**
+     * InputStream -> byte[] 변환
+     */
+    private byte[] toByteArray(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int nRead;
+        byte[] data = new byte[1024];
+
+        while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+            buffer.write(data, 0, nRead);
+        }
+        buffer.flush();
+
+        return buffer.toByteArray();
+    }
+}
+

--- a/src/main/java/com/example/dm/aspect/CustomResponseWrapper.java
+++ b/src/main/java/com/example/dm/aspect/CustomResponseWrapper.java
@@ -1,0 +1,44 @@
+package com.example.dm.aspect;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * API 응답 데이터를 작성할 때,
+ * 1. FilterServletOutputStream 객체 호출
+ * 2. write 메소드로 데이터 삽입
+ * 3. 삽입된 데이터는 filterOutput 초기화 할때 인자로 넘겨줬던 output에 실제로 데이터가 쌓임
+ * 4. 그래서 toByteArray() 메소드를 통해 byte[] 타입으로 실제 API 응답을 가져올 수 있음.
+ */
+public class CustomResponseWrapper extends HttpServletResponseWrapper {
+
+    ByteArrayOutputStream output; // 바이트 스트림 데이터를 담기 위한 객체
+    FilterServletOutputStream filterOutput;
+
+    /**
+     * output 초기화
+     */
+    public CustomResponseWrapper(HttpServletResponse response) {
+        super(response);
+        output = new ByteArrayOutputStream();
+    }
+
+    /**
+     * 위에서 초기화한 output 객체로 filterOutput 객체를 생성 후 리턴
+     */
+    @Override
+    public ServletOutputStream getOutputStream() {
+        if (filterOutput == null) {
+            filterOutput = new FilterServletOutputStream(output);
+        }
+        return filterOutput;
+    }
+
+    public byte[] getDataStream() {
+        return output.toByteArray();
+    }
+
+}

--- a/src/main/java/com/example/dm/aspect/FilterServletOutputStream.java
+++ b/src/main/java/com/example/dm/aspect/FilterServletOutputStream.java
@@ -1,0 +1,31 @@
+package com.example.dm.aspect;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class FilterServletOutputStream extends ServletOutputStream {
+    private final DataOutputStream outputStream;
+
+    public FilterServletOutputStream(OutputStream output) {
+        this.outputStream = new DataOutputStream(output);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        outputStream.write(b);
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener listener) {
+    }
+
+}

--- a/src/main/java/com/example/dm/aspect/LoggingFilter.java
+++ b/src/main/java/com/example/dm/aspect/LoggingFilter.java
@@ -1,0 +1,81 @@
+package com.example.dm.aspect;
+
+import com.example.dm.util.TxidGenerator;
+import jakarta.servlet.*;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.util.Strings;
+import org.springframework.util.StopWatch;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@RequiredArgsConstructor
+@Slf4j
+@WebFilter(filterName = "LoggingFilter", urlPatterns = "/api/v1/*")
+public class LoggingFilter implements Filter {
+
+    private final TxidGenerator txidGenerator;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+        // requestId 및 IP 셋팅
+        initRequestId((HttpServletRequest) request);
+        initPublicIp((HttpServletRequest) request);
+
+        CustomRequestWrapper requestWrapper = new CustomRequestWrapper((HttpServletRequest) request);
+        CustomResponseWrapper responseWrapper = new CustomResponseWrapper((HttpServletResponse) response);
+
+        filterChain.doFilter(requestWrapper, responseWrapper);
+
+        String responseBody = new String(responseWrapper.getDataStream(), StandardCharsets.UTF_8);
+        writeResponseLogs((HttpServletRequest) request, (HttpServletResponse) response, responseBody, stopWatch);
+        response.getOutputStream().write(responseBody.getBytes());
+    }
+
+    /**
+     * 메소드 실행 후 Response 로그 작성
+     */
+    private void writeResponseLogs(HttpServletRequest request, HttpServletResponse response, String responseBody, StopWatch stopWatch) {
+        String requestId = (String) request.getAttribute("requestId");
+        String requestMethod = request.getMethod();
+        String servletPath = request.getServletPath();
+        String queryString = !Strings.isEmpty(request.getQueryString()) ? "?" + request.getQueryString() : "";
+        int statusCode = response.getStatus();
+
+        if (statusCode >= 400) { // 오류
+            log.error("-------------------------------------");
+            log.error("[Response] => {}", requestId);
+            log.error("{} [Exception] {} {} {}", requestId, statusCode, requestMethod, servletPath + queryString);
+            log.error("{} response body=[{}]", requestId, responseBody);
+
+        } else { // 성공
+            log.info("-------------------------------------");
+            log.info("[Response] => {}", requestId);
+            log.info("{} [Success] {} {} {}", requestId, statusCode, requestMethod, servletPath + queryString);
+            log.info("{} response body=[{}]", requestId, responseBody);
+        }
+
+        stopWatch.stop();
+        long durationMs = stopWatch.getTotalTimeMillis();
+
+        log.info("{} duration time:{}ms", requestId, durationMs);
+        log.info("-------------------------------------");
+    }
+
+    private void initRequestId(HttpServletRequest request) {
+        request.setAttribute("requestId", txidGenerator.getTxid());
+    }
+
+    private void initPublicIp(HttpServletRequest request) {
+        String publicIp = request.getRemoteAddr();
+        request.setAttribute("publicIp", publicIp);
+    }
+
+}


### PR DESCRIPTION
## Add: 전역 Logging 모듈 추가

- 요청, 응답 시 `txid`, `method`, `URI`, `public ip`, `user agent`, `status code`, `body`, `duration time` 정보를 로깅하는 모듈 추가
- Custom Filter 클래스에서 요청, 응답 전후를 감싸서(랩핑) 로그를 찍는 방식

### 요청 로깅 예시
```
[Request] => da22d960-1422-49e0-90b2-bfecfb1ad296
da22d960-1422-49e0-90b2-bfecfb1ad296 GET /api/v1/commons/test
da22d960-1422-49e0-90b2-bfecfb1ad296 public ip:0:0:0:0:0:0:0:1
da22d960-1422-49e0-90b2-bfecfb1ad296 user-agent:PostmanRuntime/7.32.3
da22d960-1422-49e0-90b2-bfecfb1ad296 request body=[]
```

### 응답 로깅 예시
```
[Response] => da22d960-1422-49e0-90b2-bfecfb1ad296
da22d960-1422-49e0-90b2-bfecfb1ad296 [Success] 200 GET /api/v1/commons/test
da22d960-1422-49e0-90b2-bfecfb1ad296 response body=[{"txid":"da22d960-1422-49e0-90b2-bfecfb1ad296","status":200,"message":"정상적으로 처리되었습니다.","data":true}]
da22d960-1422-49e0-90b2-bfecfb1ad296 duration time:31ms
```