### PR TITLE
Add: Kafka 연동관련 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     // MimeType
     implementation group: 'org.apache.tika', name: 'tika-parsers', version: '1.28.3'
 
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka:2.9.10'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -5,6 +5,14 @@ volumes:
     external: false
   redis-data:
     external: false
+  zookeeper-data:
+    external: false
+  kafka-data:
+    external: false
+
+networks:
+  kafka-net:
+    driver: bridge
 
 services:
   postgres:
@@ -36,11 +44,55 @@ services:
     command: redis-server --requirepass ${REDIS_PASSWORD}
     restart: always
 
+  zookeeper:
+    container_name: dev_mingle_zookeeper
+    image: zookeeper:3.9.0
+    ports:
+      - "2181:2181"
+    networks:
+      - kafka-net
+    environment:
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_INIT_LIMIT: 5
+      ZOOKEEPER_SYNC_LIMIT: 2
+    volumes:
+      - zookeeper-data:/data
+    restart: always
+
+  kafka:
+    container_name: dev_mingle_kafka
+    image: bitnami/kafka
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    networks:
+      - kafka-net
+    hostname: dev_mingle_kafka
+    env_file: .env
+    environment:
+      # KRaft settings
+      KAFKA_CFG_NODE_ID: 0
+      KAFKA_CFG_PROCESS_ROLES: controller,broker
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@kafka:9093
+      # Listeners
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://:9092
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    restart: always
+
   api:
     container_name: dev_mingle_api
     depends_on:
       - postgres
       - redis
+      - kafka
     ports:
       - "8080:8080"
     build:

--- a/src/main/java/com/example/dm/config/KafkaConfig.java
+++ b/src/main/java/com/example/dm/config/KafkaConfig.java
@@ -1,0 +1,87 @@
+package com.example.dm.config;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * https://www.baeldung.com/spring-kafka 참조
+ */
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.consumer.bootstrap-servers}")
+    private String BOOTSTRAP_SERVER;
+
+    @Bean
+    public KafkaAdmin kafkaAdmin() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVER);
+        return new KafkaAdmin(configs);
+    }
+
+    /**
+     * notice 토픽 생성
+     */
+    @Bean
+    public NewTopic notice() {
+        return new NewTopic("notice", 1, (short) 1);
+    }
+
+    /**
+     * Default Kafka Template
+     */
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    /**
+     * Default Producer Factory
+     */
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVER);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+
+    /**
+     * Default Kafka Listener Container Factory
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    /**
+     * Default Consumer Factory
+     */
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVER);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+}

--- a/src/main/java/com/example/dm/controller/KafkaController.java
+++ b/src/main/java/com/example/dm/controller/KafkaController.java
@@ -1,0 +1,27 @@
+package com.example.dm.controller;
+
+import com.example.dm.dto.ApiResponse;
+import com.example.dm.dto.commons.KafkaDto;
+import com.example.dm.service.KafkaProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("${api.path.default}/kafka")
+public class KafkaController extends BaseController {
+
+    private final KafkaProducer kafkaProducer;
+
+    /**
+     * 특정 토픽으로 메시지 발행 테스트
+     */
+    @PostMapping("/test")
+    public ResponseEntity<ApiResponse> produceTest(@RequestBody KafkaDto.InputDto inputDto) {
+        kafkaProducer.sendMessage(inputDto);
+        return responseBuilder(new KafkaDto.OutputDto(inputDto), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/example/dm/dto/commons/KafkaDto.java
+++ b/src/main/java/com/example/dm/dto/commons/KafkaDto.java
@@ -1,0 +1,36 @@
+package com.example.dm.dto.commons;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+public class KafkaDto {
+
+    @Getter
+    @Setter
+    @ToString
+    public static class InputDto {
+        private String topic;
+        private String message;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    public static class OutputDto {
+        private String topic;
+        private String message;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime timestamp;
+
+        public OutputDto(InputDto inputDto) {
+            this.topic = inputDto.getTopic();
+            this.message = inputDto.getMessage();
+            this.timestamp = LocalDateTime.now();
+        }
+    }
+
+}

--- a/src/main/java/com/example/dm/service/KafkaConsumer.java
+++ b/src/main/java/com/example/dm/service/KafkaConsumer.java
@@ -1,0 +1,16 @@
+package com.example.dm.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class KafkaConsumer {
+
+    @KafkaListener(topics = "test-topic", groupId = "test-group")
+    public void testTopicConsume(String message) {
+        log.info("Consumer message : {}", message);
+    }
+
+}

--- a/src/main/java/com/example/dm/service/KafkaProducer.java
+++ b/src/main/java/com/example/dm/service/KafkaProducer.java
@@ -1,0 +1,39 @@
+package com.example.dm.service;
+
+import com.example.dm.dto.commons.KafkaDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class KafkaProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    /**
+     * 특정 토픽으로 메시지 발행
+     *
+     * @param inputDto
+     */
+    public void sendMessage(KafkaDto.InputDto inputDto) {
+        // 비동기로 메시지 발행
+        CompletableFuture<SendResult<String, String>> future = kafkaTemplate.send(inputDto.getTopic(), inputDto.getMessage()).completable();
+
+        future.whenComplete((result, ex) -> {
+            if (ex == null) { // 발행 성공
+                log.info("[Produce Success] topic={}, message={}, offset={}", inputDto.getTopic(), inputDto.getMessage(), result.getRecordMetadata().offset());
+
+            } else { // 발행 실패
+                log.info("[Produce Failed] topic={}, message={}, description={}", inputDto.getTopic(), inputDto.getMessage(), ex.getMessage());
+            }
+        });
+    }
+
+
+}

--- a/src/main/resources/application-auth.yml
+++ b/src/main/resources/application-auth.yml
@@ -54,3 +54,5 @@ url:
       - /users
       - /users/otp
       - /users/nickname
+      - /commons/pre-signed-url
+      - /kafka/test

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,16 @@ server:
 spring:
   profiles:
     include: datasource, auth
+  kafka:
+    producer:
+      bootstrap-servers: ${KAFKA_HOST:dev_mingle_kafka}:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      bootstrap-servers: ${KAFKA_HOST:dev_mingle_kafka}:9092
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
   output:
     ansi:


### PR DESCRIPTION
## Add: Kafka 연동관련 작업

### 연결된 이슈: 

- kafka 의존성 추가
- local 환경에서 kafka 실행 가능하도록 `docker-compose.local.yml` 수정
- kafka 관련 설정 및 환경변수 추가
  ```env
  .env
  KAFKA_HOST: dev_mingle_kafka
  ```
- kafka config 설정
- kafka DTO 추가
- kafka Producer 추가
- kafka 테스트용 컨트롤러, Consumer 작성
- 사용자 인증이 필요없는 URL 추가